### PR TITLE
Fixing footer styling issue that is present on all blog posts.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 <html>
   {% include head.html %}
     <body>
-        <section class="skycom-container">
+        <section class="skycom-container clearfix">
             <div class="alpha skycom-12">
                 {{ content }}
             </div>


### PR DESCRIPTION
The footer grey background overflowed into the blog post background. Adding a clearfix stopped this.